### PR TITLE
Styling asset details page as hyperlinks were default blue

### DIFF
--- a/style.css
+++ b/style.css
@@ -113,3 +113,4 @@ h3 {color:white;text-align:center;}
         background-size: 3px;}
 	
 #asset-container pre {color:white;text-align:center;}
+#asset-container pre a {color:white;text-align:center;}


### PR DESCRIPTION
Styling asset details page as hyperlinks were default blue