### PR TITLE
Change of copyright notice to avoid confusion

### DIFF
--- a/asset.html
+++ b/asset.html
@@ -36,7 +36,7 @@
 <div id="asset-container"></div>
 
     
-<p id="copyright">&copy 2023 STAMPS Protocol</p>
+<p id="copyright">&copy 2023 Bitcoin Stamps</p>
     
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 	<div id="pagination-container-bottom"></div>
 
 	
-	<p id="copyright">&copy 2023 STAMPS Protocol</p>
+	<p id="copyright">&copy 2023 Bitcoin Stamps</p>
   
 </body>
 </html>

--- a/mint/index.html
+++ b/mint/index.html
@@ -50,7 +50,7 @@
         <p id="please-wait" hidden>Please wait...Building Your Transaction...</p>
         <div id="output"></div>
         <p id="confirmation-message" hidden>You will receive no further confirmation on this page. Please monitor the artist / creator wallet for the incoming stamp. Non-image files are not supported on the STAMP protocol.</p>
-        <p id="notes">Stamps will be minted on the block after confirmation of payment, and sent on the next block after issuance confirmation.<br>Please contact us for bulk minting services. A convenience charge is added when using this service.<br><br><a href="https://github.com/mikeinspace/stamps/blob/main/Key-Burn.md" target="_blank">Key Burn</a> is now implemented through this minting service.</p>
+        <p id="notes">Stamps will be minted on the block after confirmation of payment, and sent on the next block after issuance confirmation.<br>Please contact us for bulk minting services. A convenience charge is added when using this service.<br><br><a href="https://github.com/mikeinspace/stamps/blob/main/Key-Burn.md" target="_blank" style="color:white;">Key Burn</a> is now implemented through this minting service.</p>
     </div>
     <!DOCTYPE html>
 

--- a/minting.html
+++ b/minting.html
@@ -49,7 +49,7 @@
 	
 	
 
-  <p id="copyright">&copy 2023 STAMPS Protocol</p>
+  <p id="copyright">&copy 2023 Bitcoin Stamps</p>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
I changed the copyright notice at the bottom of the pages from STAMPS Protocol to Bitcoin Stamps.

Want to ensure confusion is avoided.

I also made the color of the "Key Burn" link white as it was blue which is hard to see on the black background.